### PR TITLE
Add cart total test

### DIFF
--- a/tests/cartService.spec.ts
+++ b/tests/cartService.spec.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { getCartTotal } from '../src/lib/cartService';
+
+describe('getCartTotal', () => {
+  it('correctly sums price × quantity for multiple cart items', () => {
+    const items = [
+      { id: '1', name: 'Item 1', price: 10, quantity: 2 },
+      { id: '2', name: 'Item 2', price: 5, quantity: 3 },
+    ];
+
+    expect(getCartTotal(items)).toBe(10 * 2 + 5 * 3);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './vitest.setup.ts',
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'tests/**/*.{test,spec}.{ts,tsx}'],
   },
 }); 


### PR DESCRIPTION
## Summary
- test `getCartTotal` for multiple items
- include tests directory in Vitest config

## Testing
- `npx vitest run tests/cartService.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_6840e3272b08832b8c7a970a890995fe