### PR TITLE
Merge duplicate catch block in productService

### DIFF
--- a/src/lib/productService.ts
+++ b/src/lib/productService.ts
@@ -1,7 +1,28 @@
-import { getFirestore, collection, addDoc, getDocs, doc, updateDoc, deleteDoc, query, limit as firestoreLimit, startAfter as firestoreStartAfter, QuerySnapshot, DocumentSnapshot, FirestoreError } from "firebase/firestore";
-import { FirebaseStorage, getStorage, ref, deleteObject, StorageReference, StorageError } from "firebase/storage";
+import {
+  getFirestore,
+  collection,
+  addDoc,
+  getDocs,
+  doc,
+  updateDoc,
+  deleteDoc,
+  query,
+  limit as firestoreLimit,
+  startAfter as firestoreStartAfter,
+  QuerySnapshot,
+  DocumentSnapshot,
+  FirestoreError,
+} from "firebase/firestore";
+import {
+  FirebaseStorage,
+  getStorage,
+  ref,
+  deleteObject,
+  StorageReference,
+  StorageError,
+} from "firebase/storage";
 // Assuming Firebase app is initialized elsewhere
-import { uploadImageToFirebaseStorage } from './storageService'; // Import the storage service
+import { uploadImageToFirebaseStorage } from "./storageService"; // Import the storage service
 // import { app } from './firebase'; // Example import
 
 const db = getFirestore(/* app */); // Initialize Firebase Firestore with your app
@@ -19,41 +40,56 @@ export interface Product {
 
 // Define custom error classes
 export class GetProductsError extends Error {
-  constructor(message: string, public originalError?: any) {
+  constructor(
+    message: string,
+    public originalError?: any,
+  ) {
     super(`Failed to get products: ${message}`);
-    this.name = 'GetProductsError';
+    this.name = "GetProductsError";
   }
 }
 
 export class AddProductError extends Error {
-  constructor(message: string, public originalError?: any) {
+  constructor(
+    message: string,
+    public originalError?: any,
+  ) {
     super(`Failed to add product: ${message}`);
-    this.name = 'AddProductError';
+    this.name = "AddProductError";
   }
 }
 
 export class UpdateProductError extends Error {
-  constructor(message: string, public originalError?: any) {
+  constructor(
+    message: string,
+    public originalError?: any,
+  ) {
     super(`Failed to update product: ${message}`);
-    this.name = 'UpdateProductError';
+    this.name = "UpdateProductError";
   }
 }
 
 export class DeleteProductError extends Error {
-  constructor(message: string, public originalError?: any) {
+  constructor(
+    message: string,
+    public originalError?: any,
+  ) {
     super(`Failed to delete product: ${message}`);
-    this.name = 'DeleteProductError';
+    this.name = "DeleteProductError";
   }
 }
 
 const productsCollection = collection(db, "products");
 
 interface PaginatedProducts {
- products: Product[];
- lastDoc: DocumentSnapshot | null;
+  products: Product[];
+  lastDoc: DocumentSnapshot | null;
 }
 
-export const addProduct = async (productData: Omit<Product, 'id' | 'imageUrl'>, imageFile?: File): Promise<string> => {
+export const addProduct = async (
+  productData: Omit<Product, "id" | "imageUrl">,
+  imageFile?: File,
+): Promise<string> => {
   try {
     let imageUrl: string | undefined = productData.imageUrl; // Allow adding with pre-existing URL if needed
     if (imageFile) {
@@ -62,12 +98,18 @@ export const addProduct = async (productData: Omit<Product, 'id' | 'imageUrl'>, 
         imageUrl = await uploadImageToFirebaseStorage(imageFile, storagePath);
       } catch (storageError) {
         console.error("Error uploading product image:", storageError);
-        throw new AddProductError("Failed to upload product image.", storageError);
+        throw new AddProductError(
+          "Failed to upload product image.",
+          storageError,
+        );
       }
     }
 
     // Ensure price is a number
-    const price = typeof productData.price === 'string' ? parseFloat(productData.price) : productData.price;
+    const price =
+      typeof productData.price === "string"
+        ? parseFloat(productData.price)
+        : productData.price;
 
     const productDataWithImage = { ...productData, imageUrl };
     const docRef = await addDoc(productsCollection, productDataWithImage);
@@ -78,15 +120,25 @@ export const addProduct = async (productData: Omit<Product, 'id' | 'imageUrl'>, 
     if (e instanceof AddProductError) {
       throw e; // Re-throw custom errors
     }
-    throw new AddProductError('An unknown error occurred while adding the product.', e);
+    throw new AddProductError(
+      "An unknown error occurred while adding the product.",
+      e,
+    );
   }
 };
 
-export const getProducts = async (limit = 10, startAfter?: DocumentSnapshot): Promise<PaginatedProducts> => {
+export const getProducts = async (
+  limit = 10,
+  startAfter?: DocumentSnapshot,
+): Promise<PaginatedProducts> => {
   try {
     let productsQuery = query(productsCollection, firestoreLimit(limit));
     if (startAfter) {
- productsQuery = query(productsCollection, firestoreLimit(limit), firestoreStartAfter(startAfter));
+      productsQuery = query(
+        productsCollection,
+        firestoreLimit(limit),
+        firestoreStartAfter(startAfter),
+      );
     }
 
     const querySnapshot: QuerySnapshot = await getDocs(productsQuery);
@@ -96,17 +148,24 @@ export const getProducts = async (limit = 10, startAfter?: DocumentSnapshot): Pr
     });
     console.log("Retrieved products:", products);
     const lastDoc = querySnapshot.docs[querySnapshot.docs.length - 1] || null;
- return { products, lastDoc };
+    return { products, lastDoc };
   } catch (e) {
     console.error("Error fetching products:", e);
-     if (e instanceof FirestoreError) {
-       throw new GetProductsError(e.message, e);
+    if (e instanceof FirestoreError) {
+      throw new GetProductsError(e.message, e);
     }
-    throw new GetProductsError('An unknown error occurred while fetching products.', e);
+    throw new GetProductsError(
+      "An unknown error occurred while fetching products.",
+      e,
+    );
   }
 };
 
-export const updateProduct = async (productId: string, productData: Partial<Omit<Product, 'id' | 'imageUrl'>>, imageFile?: File): Promise<void> => {
+export const updateProduct = async (
+  productId: string,
+  productData: Partial<Omit<Product, "id" | "imageUrl">>,
+  imageFile?: File,
+): Promise<void> => {
   try {
     let imageUrl: string | undefined = productData.imageUrl; // Keep existing image if not replaced
     if (imageFile) {
@@ -116,18 +175,24 @@ export const updateProduct = async (productId: string, productData: Partial<Omit
 
         // Consider deleting the old image if a new one was uploaded and an old one existed
         if (productData.imageUrl) {
-             try {
-                const storage = getStorage();
-                const oldImageRef = ref(storage, productData.imageUrl);
-                await deleteObject(oldImageRef);
-             } catch (deleteError: any) {
-                 console.warn("Could not delete old product image:", deleteError);
-                 // Continue update even if old image deletion fails
-             }
+          try {
+            const storage = getStorage();
+            const oldImageRef = ref(storage, productData.imageUrl);
+            await deleteObject(oldImageRef);
+          } catch (deleteError: any) {
+            console.warn("Could not delete old product image:", deleteError);
+            // Continue update even if old image deletion fails
+          }
         }
       } catch (storageError) {
-         console.error("Error uploading new product image for update:", storageError);
-         throw new UpdateProductError("Failed to upload new product image.", storageError);
+        console.error(
+          "Error uploading new product image for update:",
+          storageError,
+        );
+        throw new UpdateProductError(
+          "Failed to upload new product image.",
+          storageError,
+        );
       }
     }
     const productRef = doc(db, "products", productId);
@@ -135,18 +200,20 @@ export const updateProduct = async (productId: string, productData: Partial<Omit
     console.log("Product with ID", productId, "updated");
   } catch (e) {
     console.error("Error updating product:", e);
-    throw e;
-  }
-   catch (e) {
-    console.error("Error updating product:", e);
-     if (e instanceof UpdateProductError) {
-       throw e; // Re-throw custom errors
+    if (e instanceof UpdateProductError) {
+      throw e; // Re-throw custom errors
     }
-    throw new UpdateProductError('An unknown error occurred while updating the product.', e);
+    throw new UpdateProductError(
+      "An unknown error occurred while updating the product.",
+      e,
+    );
   }
 };
 
-export const deleteProduct = async (productId: string, imageUrl?: string): Promise<void> => {
+export const deleteProduct = async (
+  productId: string,
+  imageUrl?: string,
+): Promise<void> => {
   try {
     const productRef = doc(db, "products", productId);
     await deleteDoc(productRef);


### PR DESCRIPTION
## Summary
- merge the duplicate catch in `updateProduct`
- keep custom error handling intact

## Testing
- `npx -y @biomejs/biome lint src/lib/productService.ts`
- `npx -y tsc --noEmit src/lib/productService.ts`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e32112a4832b9ca126b43f5fa8c6