### PR TITLE
Fix AdminGalleryEditor export and imports

### DIFF
--- a/src/components/AdminGalleryEditor.tsx
+++ b/src/components/AdminGalleryEditor.tsx
@@ -1,6 +1,7 @@
 // Instructions: Update AdminGalleryEditor.tsx to use the revised services, add fields for title and description, improve UI, and handle Timestamps.
 
 // ... existing code ... <imports>
+import React, { useState, useEffect } from 'react';
 import { getGalleryImages, addGalleryImage, deleteGalleryImage, GalleryImage, NewGalleryImageData } from '../lib/galleryService';
 import { uploadImageToFirebaseStorage, deleteImageFromFirebaseStorage } from '../lib/storageService';
 import { useSession } from 'next-auth/react';
@@ -190,6 +191,11 @@ const AdminGalleryEditor: React.FC = () => {
               </button>
               <p className="text-xs text-gray-500 mt-1">Uploaded: {image.uploadedAt instanceof Timestamp ? image.uploadedAt.toDate().toLocaleDateString() : 'Date N/A'}</p>
             </li>
-          ))}
-        </ul>
-      </div>
+      ))}
+    </ul>
+  </div>
+  );
+
+};
+
+export default AdminGalleryEditor;


### PR DESCRIPTION
## Summary
- add missing React import
- close AdminGalleryEditor component and export it

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e99c17c8832b9392033ed037e50c