### PR TITLE
Add TODO timestamp hook

### DIFF
--- a/.github/workflows/check-timestamp.yml
+++ b/.github/workflows/check-timestamp.yml
@@ -1,0 +1,18 @@
+name: Check TODO Timestamp
+
+on:
+  pull_request:
+    paths: ["TODO.md"]
+
+jobs:
+  timestamp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate timestamp placeholder
+        run: |
+          if grep -q "{{AUTO_TIMESTAMP}}" TODO.md; then
+            echo "Placeholder {{AUTO_TIMESTAMP}} found. Run pre-commit hook." >&2
+            exit 1
+          fi
+

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug () {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky > $1"
+  }
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+  if [ "$HUSKY" = "skip" ]; then
+    debug "HUSKY skip env variable is set"
+    exit 0
+  fi
+  if [ -f ~/.huskyrc ]; then
+    debug "source ~/.huskyrc"
+    . ~/.huskyrc
+  fi
+  export readonly husky_skip_init=1
+  sh -e "$0.local" "$@"
+  exit $?
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+node scripts/update-todo-timestamp.js

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # wretched-designs
- wretched-designs
+Wretched Designs
+
+## Git Hooks
+
+This project uses a Husky pre-commit hook to automatically replace any
+`{{AUTO_TIMESTAMP}}` placeholder in `TODO.md` with the current ISO time. The hook
+executes `scripts/update-todo-timestamp.js` before each commit.
+
+After cloning the repository, run `npm install` once to set up Husky. The hook
+will run on every commit and update the timestamp.
+
+## Continuous Integration
+
+A GitHub Actions workflow verifies that `TODO.md` does not contain the timestamp
+placeholder. Pull requests will fail if `{{AUTO_TIMESTAMP}}` is still present.
+

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "test": "vitest run",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "prepare": "husky install"
   },
   "dependencies": {
     "@stripe/react-stripe-js": "^3.7.0",
@@ -50,6 +51,7 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5",
-    "vitest": "^3.1.4"
+    "vitest": "^3.1.4",
+    "husky": "^9.0.11"
   }
 }

--- a/scripts/update-todo-timestamp.js
+++ b/scripts/update-todo-timestamp.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const filePath = path.join(__dirname, '..', 'TODO.md');
+if (!fs.existsSync(filePath)) {
+  process.exit(0);
+}
+let content = fs.readFileSync(filePath, 'utf8');
+const lines = content.split(/\r?\n/);
+const placeholder = '{{AUTO_TIMESTAMP}}';
+let updated = false;
+const timestamp = new Date().toISOString();
+
+const newLines = lines.map((line) => {
+  if (line.includes(placeholder) && !line.includes('Auto-update Timestamp')) {
+    updated = true;
+    return line.replace(new RegExp(placeholder, 'g'), timestamp);
+  }
+  return line;
+});
+
+if (updated) {
+  fs.writeFileSync(filePath, newLines.join('\n'));
+  console.log(`Updated TODO.md timestamp to ${timestamp}`);
+}
+
+


### PR DESCRIPTION
## Summary
- add Husky pre-commit hook that updates `TODO.md`
- document hook usage and CI check
- add GitHub Actions workflow to ensure placeholder is removed

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ef182b1c832b8198e6e5e21fa85c