### PR TITLE
Add environment guard for admin tools

### DIFF
--- a/src/app/about/admin/page.tsx
+++ b/src/app/about/admin/page.tsx
@@ -2,32 +2,43 @@
 import { useState } from "react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import dynamic from 'next/dynamic';
+import dynamic from "next/dynamic";
 
 export default function AboutAdminPage() {
+  if (process.env.NODE_ENV === "production") {
+    return null;
+  }
   const { data: session, status } = useSession();
   const router = useRouter();
 
-  if (status === 'loading') {
+  if (status === "loading") {
     return <div>Loading...</div>;
   }
 
-  if (status === 'unauthenticated' || session?.user?.role !== 'admin') {
-    router.push('/api/auth/signin');
+  if (status === "unauthenticated" || session?.user?.role !== "admin") {
+    router.push("/api/auth/signin");
     return null; // or a loading spinner, or nothing
   }
   // Demo state for editing
   const [title, setTitle] = useState("Our Story");
-  const [bio, setBio] = useState("Hey! I'm Julio, the creative spirit behind this brand.\nWhat started as a side hustle with cups turned into a full-blown lifestyle collection.\nEvery design is crafted with intention — blending function, fun, and flair.\nThanks for supporting this journey. You're not just a customer — you're part of the vibe.");
+  const [bio, setBio] = useState(
+    "Hey! I'm Julio, the creative spirit behind this brand.\nWhat started as a side hustle with cups turned into a full-blown lifestyle collection.\nEvery design is crafted with intention — blending function, fun, and flair.\nThanks for supporting this journey. You're not just a customer — you're part of the vibe.",
+  );
   const [profile, setProfile] = useState("/alex-placeholder.png");
 
   // Dynamically import components used only in the admin section
-  const DynamicAdminOverlay = dynamic(() => import('../../../components/AdminOverlay'));
-  const DynamicEditableText = dynamic(() => import('../../../components/EditableText'));
-  const DynamicEditableImage = dynamic(() => import('../../../components/EditableImage'));
+  const DynamicAdminOverlay = dynamic(
+    () => import("../../../components/AdminOverlay"),
+  );
+  const DynamicEditableText = dynamic(
+    () => import("../../../components/EditableText"),
+  );
+  const DynamicEditableImage = dynamic(
+    () => import("../../../components/EditableImage"),
+  );
 
   // Render a loading state or null while dynamic components are loading
-  if (typeof window === 'undefined') {
+  if (typeof window === "undefined") {
     return null;
   }
 
@@ -35,15 +46,27 @@ export default function AboutAdminPage() {
     <DynamicAdminOverlay>
       <section className="relative flex flex-col items-center justify-center min-h-[80vh] w-full overflow-hidden p-4">
         <div className="w-full max-w-2xl mx-auto bg-matte-black/80 rounded-xl shadow-lg p-8 flex flex-col items-center mb-10">
-          <DynamicEditableText value={title} onSave={setTitle} className="text-2xl font-header mb-4 text-acid-magenta" />
+          <DynamicEditableText
+            value={title}
+            onSave={setTitle}
+            className="text-2xl font-header mb-4 text-acid-magenta"
+          />
           <div className="flex flex-col md:flex-row items-center gap-6">
-            <DynamicEditableImage src={profile} onSave={setProfile} alt="Profile" />
+            <DynamicEditableImage
+              src={profile}
+              onSave={setProfile}
+              alt="Profile"
+            />
             <blockquote className="text-lg md:text-xl text-white/90 leading-relaxed text-left">
-              <DynamicEditableText value={bio} onSave={setBio} className="mb-4 block whitespace-pre-line" />
+              <DynamicEditableText
+                value={bio}
+                onSave={setBio}
+                className="mb-4 block whitespace-pre-line"
+              />
             </blockquote>
           </div>
         </div>
       </section>
     </DynamicAdminOverlay>
   );
-} 
+}

--- a/src/app/gallery/admin/page.tsx
+++ b/src/app/gallery/admin/page.tsx
@@ -1,8 +1,8 @@
-'use client';
+"use client";
 
-import { Component, useEffect, useState, ErrorInfo } from 'react';
-import { useSession } from 'next-auth/react';
-import { useRouter } from 'next/navigation';
+import { Component, useEffect, useState, ErrorInfo } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
 
 interface GalleryItem {
   id: string;
@@ -42,6 +42,9 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 }
 
 const AdminGalleryPage = () => {
+  if (process.env.NODE_ENV === "production") {
+    return null;
+  }
   const { data: session, status } = useSession();
   const router = useRouter();
   const [galleryItems, setGalleryItems] = useState<GalleryItem[]>([]);
@@ -51,10 +54,10 @@ const AdminGalleryPage = () => {
   const [uploadError, setUploadError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (status === 'loading') return;
+    if (status === "loading") return;
     // Assuming session.user.isAdmin indicates admin
     if (!session || !(session.user as any)?.isAdmin) {
-      router.push('/admin'); // Redirect to admin login or dashboard if not authorized
+      router.push("/admin"); // Redirect to admin login or dashboard if not authorized
     } else {
       fetchGalleryItems();
     }
@@ -64,7 +67,7 @@ const AdminGalleryPage = () => {
     setLoading(true);
     setFetchError(null);
     try {
-      const res = await fetch('/api/gallery');
+      const res = await fetch("/api/gallery");
       if (!res.ok) {
         throw new Error(`HTTP error! status: ${res.status}`);
       }
@@ -72,7 +75,7 @@ const AdminGalleryPage = () => {
       setGalleryItems(data);
     } catch (err: any) {
       setFetchError(err.message);
-      console.error('Error fetching gallery items:', fetchError);
+      console.error("Error fetching gallery items:", fetchError);
     } finally {
       setLoading(false);
     }
@@ -89,23 +92,23 @@ const AdminGalleryPage = () => {
 
   const handleUpload = async () => {
     if (!selectedFile) {
-      setUploadError('Please select a file to upload.');
+      setUploadError("Please select a file to upload.");
       return;
     }
 
-    if (!selectedFile.type.startsWith('image/')) {
-      setUploadError('Please select an image file.');
+    if (!selectedFile.type.startsWith("image/")) {
+      setUploadError("Please select an image file.");
       return;
     }
 
     setLoading(true);
     setUploadError(null);
     const formData = new FormData();
-    formData.append('image', selectedFile);
+    formData.append("image", selectedFile);
 
     try {
-      const res = await fetch('/api/gallery', {
-        method: 'POST',
+      const res = await fetch("/api/gallery", {
+        method: "POST",
         body: formData,
       });
 
@@ -118,7 +121,7 @@ const AdminGalleryPage = () => {
       setSelectedFile(null); // Clear selected file
     } catch (err: any) {
       setUploadError(err.message);
-      console.error('Error uploading image:', uploadError);
+      console.error("Error uploading image:", uploadError);
     } finally {
       setLoading(false);
     }
@@ -128,10 +131,10 @@ const AdminGalleryPage = () => {
     setLoading(true);
     setFetchError(null); // Use fetchError for operations on existing items
     try {
-      const res = await fetch('/api/gallery', {
-        method: 'DELETE',
+      const res = await fetch("/api/gallery", {
+        method: "DELETE",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({ id }),
       });
@@ -144,63 +147,85 @@ const AdminGalleryPage = () => {
       await fetchGalleryItems();
     } catch (err: any) {
       setFetchError(err.message);
-      console.error('Error deleting image:', fetchError);
+      console.error("Error deleting image:", fetchError);
     } finally {
       setLoading(false);
     }
   };
 
-  if (status === 'loading') {
+  if (status === "loading") {
     return <div>Loading authentication...</div>;
   }
 
   // Assuming session and isAdmin check in useEffect handles unauthorized redirect
   if (!session || !(session.user as any)?.isAdmin) {
-     return <div>Redirecting...</div>;
+    return <div>Redirecting...</div>;
   }
-
 
   // Render the main content within the ErrorBoundary
   return (
     <ErrorBoundary>
-      <div style={{ padding: '20px' }}>
+      <div style={{ padding: "20px" }}>
         <h1>Admin Gallery Management</h1>
 
-        <div style={{ marginBottom: '20px', border: '1px solid #ccc', padding: '15px' }}>
+        <div
+          style={{
+            marginBottom: "20px",
+            border: "1px solid #ccc",
+            padding: "15px",
+          }}
+        >
           <h2>Upload New Image</h2>
           <input type="file" accept="image/*" onChange={handleFileChange} />
           <button onClick={handleUpload} disabled={!selectedFile || loading}>
-            {loading ? 'Uploading...' : 'Upload Image'}
+            {loading ? "Uploading..." : "Upload Image"}
           </button>
-          {uploadError && <p style={{ color: 'red' }}>Upload failed: {uploadError}</p>}
+          {uploadError && (
+            <p style={{ color: "red" }}>Upload failed: {uploadError}</p>
+          )}
         </div>
 
         <h2>Existing Gallery Items</h2>
         {loading && <p>Loading gallery...</p>}
-        {fetchError && <p style={{ color: 'red' }}>Error fetching or deleting images: {fetchError}</p>}
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '15px' }}>
+        {fetchError && (
+          <p style={{ color: "red" }}>
+            Error fetching or deleting images: {fetchError}
+          </p>
+        )}
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "15px" }}>
           {galleryItems.map((item) => (
-            <div key={item.id} style={{ border: '1px solid #eee', padding: '10px', position: 'relative' }}>
-              <img src={item.downloadURL} alt={`Gallery Image ${item.id}`} style={{ width: '150px', height: '150px', objectFit: 'cover' }} />
+            <div
+              key={item.id}
+              style={{
+                border: "1px solid #eee",
+                padding: "10px",
+                position: "relative",
+              }}
+            >
+              <img
+                src={item.downloadURL}
+                alt={`Gallery Image ${item.id}`}
+                style={{ width: "150px", height: "150px", objectFit: "cover" }}
+              />
               <button
                 onClick={() => handleDelete(item.id)}
                 disabled={loading}
                 style={{
-                  position: 'absolute',
-                  top: '5px',
-                  right: '5px',
-                  backgroundColor: 'rgba(255, 0, 0, 0.7)',
-                  color: 'white',
-                  border: 'none',
-                  borderRadius: '50%',
-                  width: '25px',
-                  height: '25px',
-                  cursor: 'pointer',
-                  display: 'flex',
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  fontSize: '14px',
-                  fontWeight: 'bold',
+                  position: "absolute",
+                  top: "5px",
+                  right: "5px",
+                  backgroundColor: "rgba(255, 0, 0, 0.7)",
+                  color: "white",
+                  border: "none",
+                  borderRadius: "50%",
+                  width: "25px",
+                  height: "25px",
+                  cursor: "pointer",
+                  display: "flex",
+                  justifyContent: "center",
+                  alignItems: "center",
+                  fontSize: "14px",
+                  fontWeight: "bold",
                 }}
               >
                 X

--- a/src/app/shop/admin/page.tsx
+++ b/src/app/shop/admin/page.tsx
@@ -4,40 +4,62 @@ import AdminOverlay from "../../../components/AdminOverlay";
 import EditableText from "../../../components/EditableText";
 
 export default function ShopAdminPage() {
+  if (process.env.NODE_ENV === "production") {
+    return null;
+  }
   const [categories, setCategories] = useState([
     { id: "cups", name: "Cups" },
     { id: "apparel", name: "Apparel" },
   ]);
 
   function updateCategoryName(idx: number, name: string) {
-    setCategories(cats => cats.map((cat, i) => i === idx ? { ...cat, name } : cat));
+    setCategories((cats) =>
+      cats.map((cat, i) => (i === idx ? { ...cat, name } : cat)),
+    );
   }
 
   function addCategory() {
-    setCategories(cats => [...cats, { id: `cat${cats.length + 1}`, name: "New Category" }]);
+    setCategories((cats) => [
+      ...cats,
+      { id: `cat${cats.length + 1}`, name: "New Category" },
+    ]);
   }
 
   return (
     <AdminOverlay>
       <section className="relative flex flex-col items-center justify-center min-h-[80vh] w-full overflow-hidden p-4">
         <div className="text-center max-w-3xl mx-auto z-10 mb-10">
-          <h1 className="glitch-header glitch font-header text-5xl md:text-7xl mb-7 neon leading-tight tracking-[0.11em]" style={{ color: '#3A7CA5' }}>
+          <h1
+            className="glitch-header glitch font-header text-5xl md:text-7xl mb-7 neon leading-tight tracking-[0.11em]"
+            style={{ color: "#3A7CA5" }}
+          >
             Shop (Admin)
           </h1>
-          <p className="text-lg text-white/80 mb-8">Edit your shop categories below:</p>
+          <p className="text-lg text-white/80 mb-8">
+            Edit your shop categories below:
+          </p>
         </div>
         <div className="w-full max-w-2xl mx-auto flex flex-col md:flex-row gap-8 justify-center items-center">
           {categories.map((cat, idx) => (
-            <div key={cat.id} className="flex-1 bg-matte-black/80 rounded-xl shadow-lg p-10 flex flex-col items-center">
-              <EditableText value={cat.name} onSave={name => updateCategoryName(idx, name)} className="text-2xl font-header mb-2 text-acid-magenta" />
+            <div
+              key={cat.id}
+              className="flex-1 bg-matte-black/80 rounded-xl shadow-lg p-10 flex flex-col items-center"
+            >
+              <EditableText
+                value={cat.name}
+                onSave={(name) => updateCategoryName(idx, name)}
+                className="text-2xl font-header mb-2 text-acid-magenta"
+              />
             </div>
           ))}
-          <button onClick={addCategory} className="flex-1 bg-acid-magenta/20 rounded-xl shadow-lg p-10 flex flex-col items-center justify-center text-4xl text-acid-magenta hover:bg-acid-magenta/40 transition">
-            ➕
-            <span className="text-base mt-2">Add Category</span>
+          <button
+            onClick={addCategory}
+            className="flex-1 bg-acid-magenta/20 rounded-xl shadow-lg p-10 flex flex-col items-center justify-center text-4xl text-acid-magenta hover:bg-acid-magenta/40 transition"
+          >
+            ➕<span className="text-base mt-2">Add Category</span>
           </button>
         </div>
       </section>
     </AdminOverlay>
   );
-} 
+}

--- a/src/app/shop/apparel/admin/page.tsx
+++ b/src/app/shop/apparel/admin/page.tsx
@@ -14,21 +14,30 @@ type Product = {
 };
 
 export default function ShopApparelAdminPage() {
+  if (process.env.NODE_ENV === "production") {
+    return null;
+  }
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
 
   // Fetch products from API on mount
   useEffect(() => {
     fetch("/api/products?category=apparel")
-      .then(res => res.json())
-      .then(data => {
+      .then((res) => res.json())
+      .then((data) => {
         setProducts(data);
         setLoading(false);
       });
   }, []);
 
-  function updateProduct(idx: number, field: keyof Product, value: string | number | boolean) {
-    const updated = products.map((p, i) => i === idx ? { ...p, [field]: value } : p);
+  function updateProduct(
+    idx: number,
+    field: keyof Product,
+    value: string | number | boolean,
+  ) {
+    const updated = products.map((p, i) =>
+      i === idx ? { ...p, [field]: value } : p,
+    );
     setProducts(updated);
     // Persist update to API
     fetch("/api/products?category=apparel", {
@@ -46,7 +55,7 @@ export default function ShopApparelAdminPage() {
       image: "/placeholder-hoodie.png",
       available: true,
     };
-    setProducts(ps => [...ps, newProduct]);
+    setProducts((ps) => [...ps, newProduct]);
     fetch("/api/products?category=apparel", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -55,7 +64,7 @@ export default function ShopApparelAdminPage() {
   }
   function removeProduct(idx: number) {
     const product = products[idx];
-    setProducts(ps => ps.filter((_, i) => i !== idx));
+    setProducts((ps) => ps.filter((_, i) => i !== idx));
     fetch("/api/products?category=apparel", {
       method: "DELETE",
       headers: { "Content-Type": "application/json" },
@@ -67,48 +76,77 @@ export default function ShopApparelAdminPage() {
     <AdminOverlay>
       <section className="relative flex flex-col items-center justify-center min-h-[80vh] w-full overflow-hidden p-4">
         <div className="text-center max-w-3xl mx-auto z-10 mb-10">
-          <h1 className="glitch-header glitch font-header text-5xl md:text-7xl mb-7 neon leading-tight tracking-[0.11em]" style={{ color: '#3A7CA5' }}>
+          <h1
+            className="glitch-header glitch font-header text-5xl md:text-7xl mb-7 neon leading-tight tracking-[0.11em]"
+            style={{ color: "#3A7CA5" }}
+          >
             Apparel (Admin)
           </h1>
         </div>
         {loading ? (
           <div className="text-white/80 text-xl">Loading...</div>
         ) : (
-        <div className="w-full max-w-3xl mx-auto grid grid-cols-1 sm:grid-cols-2 gap-8">
-          {products.map((product, idx) => (
-            <div key={product.id} className="bg-matte-black rounded-xl shadow-lg p-6 flex flex-col items-center relative">
-              <EditableImage src={product.image} onSave={img => updateProduct(idx, "image", img)} alt={product.name} />
-              <EditableText value={product.name} onSave={name => updateProduct(idx, "name", name)} className="text-xl font-bold mb-2" />
-              <EditableText value={product.description} onSave={desc => updateProduct(idx, "description", desc)} className="text-white/80 mb-2" />
-              <div className="flex items-center gap-2 mb-2">
-                <span className="text-acid-magenta font-bold">$</span>
-                <input
-                  type="number"
-                  value={product.price}
-                  min={0}
-                  onChange={e => updateProduct(idx, "price", Number(e.target.value))}
-                  className="w-20 px-2 py-1 rounded bg-[#222] text-white border border-acid-magenta focus:outline-none focus:ring-2 focus:ring-acid-magenta"
+          <div className="w-full max-w-3xl mx-auto grid grid-cols-1 sm:grid-cols-2 gap-8">
+            {products.map((product, idx) => (
+              <div
+                key={product.id}
+                className="bg-matte-black rounded-xl shadow-lg p-6 flex flex-col items-center relative"
+              >
+                <EditableImage
+                  src={product.image}
+                  onSave={(img) => updateProduct(idx, "image", img)}
+                  alt={product.name}
                 />
-              </div>
-              <div className="flex items-center gap-2 mb-2">
-                <label className="text-white/80">Available for Sale</label>
-                <input
-                  type="checkbox"
-                  checked={product.available}
-                  onChange={e => updateProduct(idx, "available", e.target.checked)}
-                  className="accent-acid-magenta w-5 h-5"
+                <EditableText
+                  value={product.name}
+                  onSave={(name) => updateProduct(idx, "name", name)}
+                  className="text-xl font-bold mb-2"
                 />
+                <EditableText
+                  value={product.description}
+                  onSave={(desc) => updateProduct(idx, "description", desc)}
+                  className="text-white/80 mb-2"
+                />
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="text-acid-magenta font-bold">$</span>
+                  <input
+                    type="number"
+                    value={product.price}
+                    min={0}
+                    onChange={(e) =>
+                      updateProduct(idx, "price", Number(e.target.value))
+                    }
+                    className="w-20 px-2 py-1 rounded bg-[#222] text-white border border-acid-magenta focus:outline-none focus:ring-2 focus:ring-acid-magenta"
+                  />
+                </div>
+                <div className="flex items-center gap-2 mb-2">
+                  <label className="text-white/80">Available for Sale</label>
+                  <input
+                    type="checkbox"
+                    checked={product.available}
+                    onChange={(e) =>
+                      updateProduct(idx, "available", e.target.checked)
+                    }
+                    className="accent-acid-magenta w-5 h-5"
+                  />
+                </div>
+                <button
+                  onClick={() => removeProduct(idx)}
+                  className="absolute top-2 right-2 text-red-500 hover:text-red-700 text-xl font-bold"
+                >
+                  ✖️
+                </button>
               </div>
-              <button onClick={() => removeProduct(idx)} className="absolute top-2 right-2 text-red-500 hover:text-red-700 text-xl font-bold">✖️</button>
-            </div>
-          ))}
-          <button onClick={addProduct} className="bg-acid-magenta/20 rounded-xl shadow-lg p-6 flex flex-col items-center justify-center text-4xl text-acid-magenta hover:bg-acid-magenta/40 transition">
-            ➕
-            <span className="text-base mt-2">Add Item</span>
-          </button>
-        </div>
+            ))}
+            <button
+              onClick={addProduct}
+              className="bg-acid-magenta/20 rounded-xl shadow-lg p-6 flex flex-col items-center justify-center text-4xl text-acid-magenta hover:bg-acid-magenta/40 transition"
+            >
+              ➕<span className="text-base mt-2">Add Item</span>
+            </button>
+          </div>
         )}
       </section>
     </AdminOverlay>
   );
-} 
+}

--- a/src/app/shop/cups/admin/page.tsx
+++ b/src/app/shop/cups/admin/page.tsx
@@ -14,21 +14,30 @@ type Product = {
 };
 
 export default function ShopCupsAdminPage() {
+  if (process.env.NODE_ENV === "production") {
+    return null;
+  }
   const [products, setProducts] = useState<Product[]>([]);
   const [loading, setLoading] = useState(true);
 
   // Fetch products from API on mount
   useEffect(() => {
     fetch("/api/products?category=cups")
-      .then(res => res.json())
-      .then(data => {
+      .then((res) => res.json())
+      .then((data) => {
         setProducts(data);
         setLoading(false);
       });
   }, []);
 
-  function updateProduct(idx: number, field: keyof Product, value: string | number | boolean) {
-    const updated = products.map((p, i) => i === idx ? { ...p, [field]: value } : p);
+  function updateProduct(
+    idx: number,
+    field: keyof Product,
+    value: string | number | boolean,
+  ) {
+    const updated = products.map((p, i) =>
+      i === idx ? { ...p, [field]: value } : p,
+    );
     setProducts(updated);
     // Persist update to API
     fetch("/api/products?category=cups", {
@@ -46,7 +55,7 @@ export default function ShopCupsAdminPage() {
       image: "/placeholder-cup.png",
       available: true,
     };
-    setProducts(ps => [...ps, newProduct]);
+    setProducts((ps) => [...ps, newProduct]);
     fetch("/api/products?category=cups", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -55,7 +64,7 @@ export default function ShopCupsAdminPage() {
   }
   function removeProduct(idx: number) {
     const product = products[idx];
-    setProducts(ps => ps.filter((_, i) => i !== idx));
+    setProducts((ps) => ps.filter((_, i) => i !== idx));
     fetch("/api/products?category=cups", {
       method: "DELETE",
       headers: { "Content-Type": "application/json" },
@@ -67,48 +76,77 @@ export default function ShopCupsAdminPage() {
     <AdminOverlay>
       <section className="relative flex flex-col items-center justify-center min-h-[80vh] w-full overflow-hidden p-4">
         <div className="text-center max-w-3xl mx-auto z-10 mb-10">
-          <h1 className="glitch-header glitch font-header text-5xl md:text-7xl mb-7 neon leading-tight tracking-[0.11em]" style={{ color: '#3A7CA5' }}>
+          <h1
+            className="glitch-header glitch font-header text-5xl md:text-7xl mb-7 neon leading-tight tracking-[0.11em]"
+            style={{ color: "#3A7CA5" }}
+          >
             Cups (Admin)
           </h1>
         </div>
         {loading ? (
           <div className="text-white/80 text-xl">Loading...</div>
         ) : (
-        <div className="w-full max-w-3xl mx-auto grid grid-cols-1 sm:grid-cols-2 gap-8">
-          {products.map((product, idx) => (
-            <div key={product.id} className="bg-matte-black rounded-xl shadow-lg p-6 flex flex-col items-center relative">
-              <EditableImage src={product.image} onSave={img => updateProduct(idx, "image", img)} alt={product.name} />
-              <EditableText value={product.name} onSave={name => updateProduct(idx, "name", name)} className="text-xl font-bold mb-2" />
-              <EditableText value={product.description} onSave={desc => updateProduct(idx, "description", desc)} className="text-white/80 mb-2" />
-              <div className="flex items-center gap-2 mb-2">
-                <span className="text-acid-magenta font-bold">$</span>
-                <input
-                  type="number"
-                  value={product.price}
-                  min={0}
-                  onChange={e => updateProduct(idx, "price", Number(e.target.value))}
-                  className="w-20 px-2 py-1 rounded bg-[#222] text-white border border-acid-magenta focus:outline-none focus:ring-2 focus:ring-acid-magenta"
+          <div className="w-full max-w-3xl mx-auto grid grid-cols-1 sm:grid-cols-2 gap-8">
+            {products.map((product, idx) => (
+              <div
+                key={product.id}
+                className="bg-matte-black rounded-xl shadow-lg p-6 flex flex-col items-center relative"
+              >
+                <EditableImage
+                  src={product.image}
+                  onSave={(img) => updateProduct(idx, "image", img)}
+                  alt={product.name}
                 />
-              </div>
-              <div className="flex items-center gap-2 mb-2">
-                <label className="text-white/80">Available for Sale</label>
-                <input
-                  type="checkbox"
-                  checked={product.available}
-                  onChange={e => updateProduct(idx, "available", e.target.checked)}
-                  className="accent-acid-magenta w-5 h-5"
+                <EditableText
+                  value={product.name}
+                  onSave={(name) => updateProduct(idx, "name", name)}
+                  className="text-xl font-bold mb-2"
                 />
+                <EditableText
+                  value={product.description}
+                  onSave={(desc) => updateProduct(idx, "description", desc)}
+                  className="text-white/80 mb-2"
+                />
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="text-acid-magenta font-bold">$</span>
+                  <input
+                    type="number"
+                    value={product.price}
+                    min={0}
+                    onChange={(e) =>
+                      updateProduct(idx, "price", Number(e.target.value))
+                    }
+                    className="w-20 px-2 py-1 rounded bg-[#222] text-white border border-acid-magenta focus:outline-none focus:ring-2 focus:ring-acid-magenta"
+                  />
+                </div>
+                <div className="flex items-center gap-2 mb-2">
+                  <label className="text-white/80">Available for Sale</label>
+                  <input
+                    type="checkbox"
+                    checked={product.available}
+                    onChange={(e) =>
+                      updateProduct(idx, "available", e.target.checked)
+                    }
+                    className="accent-acid-magenta w-5 h-5"
+                  />
+                </div>
+                <button
+                  onClick={() => removeProduct(idx)}
+                  className="absolute top-2 right-2 text-red-500 hover:text-red-700 text-xl font-bold"
+                >
+                  ✖️
+                </button>
               </div>
-              <button onClick={() => removeProduct(idx)} className="absolute top-2 right-2 text-red-500 hover:text-red-700 text-xl font-bold">✖️</button>
-            </div>
-          ))}
-          <button onClick={addProduct} className="bg-acid-magenta/20 rounded-xl shadow-lg p-6 flex flex-col items-center justify-center text-4xl text-acid-magenta hover:bg-acid-magenta/40 transition">
-            ➕
-            <span className="text-base mt-2">Add Item</span>
-          </button>
-        </div>
+            ))}
+            <button
+              onClick={addProduct}
+              className="bg-acid-magenta/20 rounded-xl shadow-lg p-6 flex flex-col items-center justify-center text-4xl text-acid-magenta hover:bg-acid-magenta/40 transition"
+            >
+              ➕<span className="text-base mt-2">Add Item</span>
+            </button>
+          </div>
         )}
       </section>
     </AdminOverlay>
   );
-} 
+}

--- a/src/components/AdminOverlay.tsx
+++ b/src/components/AdminOverlay.tsx
@@ -2,7 +2,13 @@
 import React from "react";
 import { useSession, signIn, signOut } from "next-auth/react";
 
-export default function AdminOverlay({ children }: { children: React.ReactNode }) {
+export default function AdminOverlay({
+  children,
+}: { children: React.ReactNode }) {
+  if (process.env.NODE_ENV === "production") {
+    return <>{children}</>;
+  }
+
   const { data: session, status } = useSession();
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const isAdmin = session?.user && (session.user as any).role === "admin";
@@ -19,7 +25,9 @@ export default function AdminOverlay({ children }: { children: React.ReactNode }
     return (
       <div className="fixed inset-0 z-50 bg-black/80 flex flex-col items-center justify-center">
         <div className="bg-matte-black p-8 rounded-xl shadow-lg flex flex-col gap-4 min-w-[320px] items-center">
-          <h2 className="text-2xl font-header text-acid-magenta mb-2 text-center">Admin Login</h2>
+          <h2 className="text-2xl font-header text-acid-magenta mb-2 text-center">
+            Admin Login
+          </h2>
           <button
             onClick={() => signIn()}
             className="px-4 py-2 bg-acid-magenta text-white rounded shadow hover:bg-electric-purple transition font-bold"
@@ -40,8 +48,14 @@ export default function AdminOverlay({ children }: { children: React.ReactNode }
   }
 
   return (
-    <div className="fixed inset-0 z-[9999] bg-black/40 pointer-events-auto" style={{ pointerEvents: 'auto' }}>
-      <div className="absolute inset-0 z-[99999] flex flex-col items-center justify-start h-full" style={{ position: 'absolute', pointerEvents: 'none' }}>
+    <div
+      className="fixed inset-0 z-[9999] bg-black/40 pointer-events-auto"
+      style={{ pointerEvents: "auto" }}
+    >
+      <div
+        className="absolute inset-0 z-[99999] flex flex-col items-center justify-start h-full"
+        style={{ position: "absolute", pointerEvents: "none" }}
+      >
         {/* Done button at the bottom center */}
         <div className="fixed bottom-8 left-1/2 -translate-x-1/2 z-[100000] flex justify-center w-full pointer-events-none">
           <button
@@ -56,4 +70,4 @@ export default function AdminOverlay({ children }: { children: React.ReactNode }
       </div>
     </div>
   );
-} 
+}

--- a/tests/admin/dashboard-ui.spec.ts
+++ b/tests/admin/dashboard-ui.spec.ts
@@ -1,7 +1,14 @@
 // tests/admin/dashboard-ui.spec.ts
 
-// This is a basic structure for E2E tests for the admin dashboard.
+// Placeholder E2E style tests for the admin dashboard.
 // You would typically use a framework like Cypress or Playwright.
+import { describe, it, expect } from "vitest";
+
+describe("Admin Dashboard UI", () => {
+  it("placeholder", () => {
+    expect(true).toBe(true);
+  });
+});
 
 // Example using Playwright:
 // import { test, expect } from '@playwright/test';

--- a/tests/admin/firebase-init.spec.ts
+++ b/tests/admin/firebase-init.spec.ts
@@ -1,7 +1,8 @@
-import { initializeApp } from 'firebase/app';
-import { getFirestore } from 'firebase/firestore';
-import { getAuth } from 'firebase/auth';
-import { getStorage } from 'firebase/storage';
+import { initializeApp } from "firebase/app";
+import { getFirestore } from "firebase/firestore";
+import { getAuth } from "firebase/auth";
+import { getStorage } from "firebase/storage";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 
 // Mock Firebase configuration
 const mockFirebaseConfig = {
@@ -15,31 +16,31 @@ const mockFirebaseConfig = {
 };
 
 // Mock the firebase/app module
-jest.mock('firebase/app', () => ({
-  initializeApp: jest.fn(() => ({
+vi.mock("firebase/app", () => ({
+  initializeApp: vi.fn(() => ({
     name: 'mock-app',
     options: mockFirebaseConfig,
   })),
 }));
 
 // Mock other Firebase service modules
-jest.mock('firebase/firestore', () => ({
-  getFirestore: jest.fn(() => ({})), // Mock Firestore instance
+vi.mock("firebase/firestore", () => ({
+  getFirestore: vi.fn(() => ({})), // Mock Firestore instance
 }));
-jest.mock('firebase/auth', () => ({
-  getAuth: jest.fn(() => ({})), // Mock Auth instance
+vi.mock("firebase/auth", () => ({
+  getAuth: vi.fn(() => ({})), // Mock Auth instance
 }));
-jest.mock('firebase/storage', () => ({
-  getStorage: jest.fn(() => ({})), // Mock Storage instance
+vi.mock("firebase/storage", () => ({
+  getStorage: vi.fn(() => ({})), // Mock Storage instance
 }));
 
 describe('Firebase Initialization', () => {
   beforeEach(() => {
     // Clear mocks before each test
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
-  test('should initialize Firebase app with correct configuration', () => {
+  it('should initialize Firebase app with correct configuration', () => {
     // Assume your initialization logic calls initializeApp with the config
     // Replace with your actual initialization function call
     initializeApp(mockFirebaseConfig);
@@ -47,7 +48,7 @@ describe('Firebase Initialization', () => {
     expect(initializeApp).toHaveBeenCalledWith(mockFirebaseConfig);
   });
 
-  test('should initialize Firebase services', () => {
+  it('should initialize Firebase services', () => {
     // Assume your initialization logic calls getFirestore, getAuth, getStorage
     // Replace with your actual initialization function calls if they are separate
     initializeApp(mockFirebaseConfig); // Initialize app first if required by your logic

--- a/tests/components/AboutAdminPage.spec.tsx
+++ b/tests/components/AboutAdminPage.spec.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect, afterEach } from "vitest";
+import AboutAdminPage from "../../src/app/about/admin/page";
+
+const origEnv = process.env.NODE_ENV;
+
+afterEach(() => {
+  process.env.NODE_ENV = origEnv;
+});
+
+describe("AboutAdminPage guard", () => {
+  it("returns null in production", () => {
+    process.env.NODE_ENV = "production";
+    const { container } = render(<AboutAdminPage />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/tests/components/AdminOverlay.spec.tsx
+++ b/tests/components/AdminOverlay.spec.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import AdminOverlay from "../../src/components/AdminOverlay";
+import { useSession } from "next-auth/react";
+
+vi.mock("next-auth/react", () => ({
+  useSession: vi.fn(),
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const origEnv = process.env.NODE_ENV;
+
+afterEach(() => {
+  process.env.NODE_ENV = origEnv;
+  vi.resetAllMocks();
+});
+
+describe("AdminOverlay environment guard", () => {
+  it("renders children only when in production", () => {
+    process.env.NODE_ENV = "production";
+    useSession.mockReturnValue({ data: null, status: "unauthenticated" });
+    render(
+      <AdminOverlay>
+        <div>child</div>
+      </AdminOverlay>
+    );
+    expect(screen.getByText("child")).toBeInTheDocument();
+    expect(screen.queryByText("Done")).not.toBeInTheDocument();
+  });
+
+  it("shows editing UI when not in production", () => {
+    process.env.NODE_ENV = "development";
+    useSession.mockReturnValue({
+      data: { user: { role: "admin" } },
+      status: "authenticated",
+    });
+    render(
+      <AdminOverlay>
+        <div>child</div>
+      </AdminOverlay>
+    );
+    expect(screen.getByText("Done")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- disable `AdminOverlay` and admin pages when running in production
- adjust placeholder tests to use Vitest
- add tests for guard logic

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6840fdbecccc832baf74846822e0d9f5