### PR TITLE
Clean up instruction comments

### DIFF
--- a/src/app/checkout/checkout-page.tsx
+++ b/src/app/checkout/checkout-page.tsx
@@ -1,4 +1,4 @@
-// Instructions: Update checkout-page.tsx to properly use the Elements provider from Stripe, fetch client secret, and pass it to CheckoutForm. Also, improve loading and error states.
+// Checkout page that initializes Stripe Elements and handles payment state
 
 import { useState, useEffect } from "react";
 import { useCart } from "../../components/CartContext";
@@ -8,7 +8,6 @@ import CheckoutForm from "../../components/CheckoutForm"; // Import the updated 
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 
-// ... existing code ... <imports>
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!);
 
 export default function CheckoutPage() {

--- a/src/components/AdminGalleryEditor.tsx
+++ b/src/components/AdminGalleryEditor.tsx
@@ -1,6 +1,5 @@
-// Instructions: Update AdminGalleryEditor.tsx to use the revised services, add fields for title and description, improve UI, and handle Timestamps.
+// Admin interface for uploading and managing gallery images
 
-// ... existing code ... <imports>
 import React, { useState, useEffect } from 'react';
 import { getGalleryImages, addGalleryImage, deleteGalleryImage, GalleryImage, NewGalleryImageData } from '../lib/galleryService';
 import { uploadImageToFirebaseStorage, deleteImageFromFirebaseStorage } from '../lib/storageService';
@@ -8,8 +7,6 @@ import { useSession } from 'next-auth/react';
 // Remove direct getStorage import, rely on services
 // import { deleteObject, ref, getStorage } from 'firebase/storage';
 import { Timestamp } from 'firebase/firestore'; // Import Timestamp
-
-// ... existing code ... <GalleryImage interface is now imported>
 
 const AdminGalleryEditor: React.FC = () => {
   const [galleryImages, setGalleryImages] = useState<GalleryImage[]>([]);
@@ -50,7 +47,6 @@ const AdminGalleryEditor: React.FC = () => {
     }
   };
 
-  // ... existing code ... <handleFileSelect function>
 
   const handleUpload = async () => {
     if (!isAdmin) {
@@ -125,7 +121,6 @@ const AdminGalleryEditor: React.FC = () => {
     }
   };
 
-  // ... existing code ... <loading and admin check>
       <div className="mb-4 p-4 border rounded shadow-sm bg-gray-50">
         <h3 className="text-xl font-semibold mb-3 text-gray-700">Upload New Image</h3>
         <div className="space-y-3">

--- a/src/components/CheckoutForm.tsx
+++ b/src/components/CheckoutForm.tsx
@@ -1,4 +1,4 @@
-// Instructions: Update CheckoutForm.tsx to use PaymentElement, fetch clientSecret dynamically based on cart total, and improve error handling and user feedback.
+// Checkout form integrates with Stripe PaymentElement and handles payments
 
 import React, { useState, useEffect } from 'react';
 import { CardElement, useStripe, useElements, PaymentElement } from '@stripe/react-stripe-js';

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -1,4 +1,4 @@
-// Instructions: Update Lightbox component to accept and display title and description, and improve styling and accessibility.
+// Lightbox component displays an image in a modal with optional title and description
 
 import React, { useEffect } from "react";
 

--- a/src/lib/galleryService.ts
+++ b/src/lib/galleryService.ts
@@ -1,5 +1,4 @@
-// Instructions: Fix the GalleryImage interface, AddGalleryImageError class, use Timestamp for dates, and improve Firestore initialization and error handling.
-
+// Utility functions for managing gallery images in Firestore
 import { collection, addDoc, getDocs, deleteDoc, doc, query, orderBy, Timestamp } from "firebase/firestore";
 import { db } from './firebase'; // Corrected import
 

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -1,4 +1,4 @@
-// Instructions: Add detailed logging to [...nextauth].ts for Firebase client config, auth object initialization, and within the authorize function. Also log if NEXTAUTH_SECRET is present and enable NextAuth debug mode.
+// NextAuth configuration using Firebase admin for credential verification
 
 import NextAuth from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';


### PR DESCRIPTION
## Summary
- remove leftover `// Instructions:` comments
- clean up outdated placeholders
- add concise headers describing modules

## Testing
- `npm test` *(fails: vitest not found)*
- `npx biome check src` *(interactive prompt for install)*

------
https://chatgpt.com/codex/tasks/task_e_6841f1a896d0832b9848c15705012de4