### PR TITLE
Fix AdminGalleryEditor JSX and import placement

### DIFF
--- a/src/components/AdminGalleryEditor.tsx
+++ b/src/components/AdminGalleryEditor.tsx
@@ -1,7 +1,7 @@
+import React, { useState, useEffect } from 'react';
 // Instructions: Update AdminGalleryEditor.tsx to use the revised services, add fields for title and description, improve UI, and handle Timestamps.
 
 // ... existing code ... <imports>
-import React, { useState, useEffect } from 'react';
 import { getGalleryImages, addGalleryImage, deleteGalleryImage, GalleryImage, NewGalleryImageData } from '../lib/galleryService';
 import { uploadImageToFirebaseStorage, deleteImageFromFirebaseStorage } from '../lib/storageService';
 import { useSession } from 'next-auth/react';


### PR DESCRIPTION
## Summary
- move React hook import to the top of `AdminGalleryEditor.tsx`
- ensure JSX closes properly at the bottom

## Testing
- `npm test` *(fails: jest is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6841f199aa24832b99f318a0e169cd58